### PR TITLE
fix: webpack window undefined error

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -6,12 +6,14 @@ interface IENavigatorLanguage  {
 }
 
 export const getBrowserLocale = (defaultLocale = 'en') => {
-  const targets = window?.navigator.languages || // user language preferences list
-    [
-      (window?.navigator as IENavigatorLanguage).userLanguage || // IE 10-
-      window?.navigator.language ||              // browser ui language
-      defaultLocale,                              // there is no window (sapper | node)
-    ]
+  const targets = typeof window === 'undefined'
+    ? [defaultLocale]  // there is no window (sapper | node/webpack)
+    : window.navigator.languages || // user language preferences list
+      [
+        (window.navigator as IENavigatorLanguage).userLanguage || // IE 10-
+        window.navigator.language, // browser ui language
+      ]
+
   const currentLocales = get(locales)
 
   for (let i = 0; i < targets.length; i = i + 1) {


### PR DESCRIPTION
I build with webpack in sapper and `window?.` doesn't stop it from failing during build, so needed an undefined check here to work w/ webpack.